### PR TITLE
Add shared-ui components and utils

### DIFF
--- a/packages/shared-ui/components/OptimizedImage.jsx
+++ b/packages/shared-ui/components/OptimizedImage.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import useCachedImageUrl from '../utils/useCachedImageUrl';
+import sanitizeSrc from '../utils/sanitizeSrc';
+
+const isHosted = (url) => /^https?:\/\//i.test(url || '');
+
+const OptimizedImage = ({
+  pngUrl,
+  webpUrl,
+  alt = '',
+  loading = 'lazy',
+  cacheKey,
+  ...props
+}) => {
+  const pngRaw = useCachedImageUrl(cacheKey, pngUrl);
+  const webp = webpUrl || (pngUrl ? pngUrl.replace(/\.png$/, '.webp') : undefined);
+  const webpRaw = webp ? useCachedImageUrl(`${cacheKey || webp}-webp`, webp) : null;
+
+  const imgSrc = sanitizeSrc(isHosted(pngRaw) ? pngRaw : pngUrl);
+  const webpSrc = sanitizeSrc(isHosted(webpRaw) ? webpRaw : null);
+
+  const renderWebp = Boolean(webpSrc);
+
+  if (renderWebp) {
+    return (
+      <picture>
+        <source srcSet={webpSrc} type="image/webp" />
+        <img src={imgSrc} alt={alt} loading={loading} decoding="async" {...props} />
+      </picture>
+    );
+  }
+
+  return <img src={imgSrc} alt={alt} loading={loading} decoding="async" {...props} />;
+};
+
+export default OptimizedImage;

--- a/packages/shared-ui/components/ShareLinkModal.jsx
+++ b/packages/shared-ui/components/ShareLinkModal.jsx
@@ -1,0 +1,182 @@
+import React, { useState } from "react";
+import { doc, updateDoc } from "firebase/firestore";
+import { db } from "../firebase/config";
+import generatePassword from "../utils/generatePassword";
+
+const ShareLinkModal = ({
+  groupId,
+  url: propUrl,
+  visibility = "private",
+  requireAuth = false,
+  requirePassword = false,
+  password = "",
+  onClose,
+  onUpdate,
+}) => {
+  const [currentVisibility, setCurrentVisibility] = useState(visibility);
+  const [access, setAccess] = useState(requireAuth ? "auth" : "any");
+  const [needPw, setNeedPw] = useState(requirePassword);
+  const [pw, setPw] = useState(password);
+
+  const url =
+    propUrl || (groupId ? `${window.location.origin}/review/${groupId}` : "");
+
+  const copy = () => {
+    navigator.clipboard
+      .writeText(url)
+      .then(() => window.alert("Link copied to clipboard"))
+      .catch((err) => console.error("Failed to copy link", err));
+  };
+
+  const saveSettings = async (
+    vis = currentVisibility,
+    acc = access,
+    pwReq = needPw,
+    pwVal = pw,
+  ) => {
+    if (!groupId) return;
+    const update = {
+      visibility: vis,
+      requireAuth: acc === "auth",
+      requirePassword: acc === "any" ? pwReq : false,
+      password: acc === "any" && pwReq ? pwVal : "",
+    };
+    try {
+      await updateDoc(doc(db, "adGroups", groupId), update);
+      onUpdate && onUpdate(update);
+    } catch (err) {
+      console.error("Failed to update visibility", err);
+    }
+  };
+
+  const toggleVisibility = async () => {
+    if (currentVisibility === "public") {
+      setCurrentVisibility("private");
+      await saveSettings("private", "any", false, "");
+      setAccess("any");
+      setNeedPw(false);
+      setPw("");
+    } else {
+      let newPw = pw;
+      if (access === "any" && needPw && !newPw) newPw = generatePassword();
+      setCurrentVisibility("public");
+      setPw(newPw);
+      await saveSettings("public", access, needPw, newPw);
+    }
+  };
+
+  const handleAccessChange = async (e) => {
+    const val = e.target.value;
+    setAccess(val);
+    if (currentVisibility === "public") {
+      await saveSettings(
+        currentVisibility,
+        val,
+        val === "any" ? needPw : false,
+        pw,
+      );
+    }
+  };
+
+  const handlePwToggle = async () => {
+    const newVal = !needPw;
+    setNeedPw(newVal);
+    let newPw = pw;
+    if (newVal && !newPw) newPw = generatePassword();
+    setPw(newPw);
+    if (currentVisibility === "public" && access === "any") {
+      await saveSettings(currentVisibility, access, newVal, newPw);
+    }
+  };
+
+  const handleGenerate = async () => {
+    const newPw = generatePassword();
+    setPw(newPw);
+    if (currentVisibility === "public" && access === "any" && needPw) {
+      await saveSettings(currentVisibility, access, true, newPw);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+      <div className="bg-white p-4 rounded shadow max-w-sm w-full dark:bg-[var(--dark-sidebar-bg)] dark:text-[var(--dark-text)]">
+        <h3 className="mb-2 font-semibold">Public Review</h3>
+        <label className="flex items-center gap-2 mb-3">
+          <input
+            type="checkbox"
+            checked={currentVisibility === "public"}
+            onChange={toggleVisibility}
+          />
+          Enable Public Review
+        </label>
+        {currentVisibility === "public" && (
+          <>
+            <label className="block mb-3 text-sm">
+              Who can access this link?
+              <select
+                value={access}
+                onChange={handleAccessChange}
+                className="mt-1 w-full border rounded p-1 text-black dark:text-black"
+              >
+                <option value="any">Anyone with the link</option>
+                <option value="auth">Only authenticated users</option>
+              </select>
+            </label>
+            {access === "any" && (
+              <>
+                <label className="flex items-center gap-2 mb-3">
+                  <input
+                    type="checkbox"
+                    checked={needPw}
+                    onChange={handlePwToggle}
+                  />
+                  Require password
+                </label>
+                {needPw && (
+                  <div className="flex items-center gap-2 mb-3">
+                    <input
+                      type="text"
+                      value={pw}
+                      onChange={async (e) => {
+                        const val = e.target.value;
+                        setPw(val);
+                        if (
+                          currentVisibility === "public" &&
+                          access === "any"
+                        ) {
+                          await saveSettings(
+                            currentVisibility,
+                            access,
+                            true,
+                            val,
+                          );
+                        }
+                      }}
+                      className="flex-1 border rounded p-1 text-black dark:text-black"
+                    />
+                    <button
+                      onClick={handleGenerate}
+                      className="btn-secondary px-2 py-1"
+                    >
+                      Generate Password
+                    </button>
+                  </div>
+                )}
+              </>
+            )}
+            <button onClick={copy} className="btn-primary mb-3 px-3 py-1">
+              Copy Link
+            </button>
+          </>
+        )}
+        <div className="text-right">
+          <button onClick={onClose} className="btn-secondary px-3 py-1">
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ShareLinkModal;

--- a/packages/shared-ui/firebase/config.js
+++ b/packages/shared-ui/firebase/config.js
@@ -1,0 +1,27 @@
+import { initializeApp } from "firebase/app";
+import { getAuth } from "firebase/auth";
+import { getFirestore } from "firebase/firestore";
+import { getStorage } from "firebase/storage";
+
+// ✅ Fixed: Correct Firebase config
+// Configuration is read from the Vite environment so that sensitive values can
+// be provided via a `.env` file.
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  // Bucket is manually created in Google Cloud Storage, not a Firebase-managed
+  // bucket, so omit the `.appspot.com` suffix.
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID
+};
+
+// ✅ Initialize Firebase
+const app = initializeApp(firebaseConfig);
+
+// ✅ Export services you'll use
+export const auth = getAuth(app);
+export const db = getFirestore(app);
+export const storage = getStorage(app);
+export { app };

--- a/packages/shared-ui/index.ts
+++ b/packages/shared-ui/index.ts
@@ -1,0 +1,2 @@
+export { default as OptimizedImage } from './components/OptimizedImage.jsx';
+export { default as ShareLinkModal } from './components/ShareLinkModal.jsx';

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -2,5 +2,8 @@
   "name": "@studio-tak/shared-ui",
   "version": "1.0.0",
   "main": "index.ts",
-  "types": "index.ts"
+  "types": "index.ts",
+  "scripts": {
+    "build": "echo nothing to build"
+  }
 }

--- a/packages/shared-ui/utils/generatePassword.js
+++ b/packages/shared-ui/utils/generatePassword.js
@@ -1,0 +1,7 @@
+export default function generatePassword() {
+  const length = 12;
+  const array = new Uint8Array(length);
+  window.crypto.getRandomValues(array);
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  return Array.from(array, (x) => chars[x % chars.length]).join('');
+}

--- a/packages/shared-ui/utils/sanitizeSrc.js
+++ b/packages/shared-ui/utils/sanitizeSrc.js
@@ -1,0 +1,12 @@
+const sanitizeSrc = (url) => {
+  if (!url) return null;
+  if (/^data:/i.test(url)) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('Blocked data URI', url);
+    }
+    return null;
+  }
+  return url;
+};
+
+export default sanitizeSrc;

--- a/packages/shared-ui/utils/useCachedImageUrl.js
+++ b/packages/shared-ui/utils/useCachedImageUrl.js
@@ -1,0 +1,16 @@
+// This utility previously stored images in localStorage to speed up
+// subsequent loads. Caching has been removed, but we keep the API
+// surface in case components still import these helpers.
+
+export const cacheImageUrl = async (_key, url) => {
+  if (!url) return null;
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => resolve(url);
+    img.onerror = () => resolve(null);
+    img.src = url;
+  });
+};
+
+const useCachedImageUrl = (_key, url) => url || null;
+export default useCachedImageUrl;


### PR DESCRIPTION
## Summary
- copy components from Campfire's shared-ui
- port utility functions and firebase config
- expose Shared UI pieces via index
- add a dummy build script for shared-ui

## Testing
- `npm run -ws build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_683cd42c8f588331a77b77f58f0db791