### PR TITLE
Add Firebase dependency to shared-ui

### DIFF
--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -5,5 +5,8 @@
   "types": "index.ts",
   "scripts": {
     "build": "echo nothing to build"
+  },
+  "dependencies": {
+    "firebase": "^11.7.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,11 @@ importers:
         specifier: ^5.2.0
         version: 5.4.19(@types/node@22.15.29)
 
-  packages/shared-ui: {}
+  packages/shared-ui:
+    dependencies:
+      firebase:
+        specifier: ^11.7.3
+        version: 11.8.1
 
 packages:
 


### PR DESCRIPTION
## Summary
- add firebase dependency to `@studio-tak/shared-ui`
- update pnpm lockfile for new dependency

## Testing
- `pnpm install --lockfile-only` *(fails: connect EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683cdd3b1e6883318508a44b52f06ea0