### PR TITLE
Accept UID from CLI in run-set-admin.js

### DIFF
--- a/apps/campfire/run-set-admin.js
+++ b/apps/campfire/run-set-admin.js
@@ -5,7 +5,12 @@ admin.initializeApp({
   credential: admin.credential.cert(serviceAccount),
 });
 
-const uid = 'NG2Z0cPlICNpi1HTB0Hv9DKIte03'; // ← get from Firebase Auth user list
+const uid = process.argv[2];
+
+if (!uid) {
+  console.error('Usage: node run-set-admin.js <uid>');
+  process.exit(1);
+}
 
 admin.auth().setCustomUserClaims(uid, { admin: true })
   .then(() => {


### PR DESCRIPTION
## Summary
- enable `run-set-admin.js` to read the Firebase UID from the command line

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683ce523f2308331aaa223f0c7380905