### PR TITLE
Fix Campfire routing base path

### DIFF
--- a/apps/campfire/src/App.jsx
+++ b/apps/campfire/src/App.jsx
@@ -152,7 +152,7 @@ const App = () => {
   }
 
   return (
-    <RouterImpl>
+    <RouterImpl basename={import.meta.env.BASE_URL}>
       <ThemeWatcher />
       <RequireMfa user={user} role={role}>
         <div className="min-h-screen flex">


### PR DESCRIPTION
## Summary
- use `<RouterImpl basename={import.meta.env.BASE_URL}>` so BrowserRouter honors the Vite base path

## Testing
- `npx jest --runTestsByPath src/App.jsx` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_683d13c7abd88331bd625c7acd392a4f