### PR TITLE
Fix loading overlay rendering

### DIFF
--- a/apps/campfire/src/App.jsx
+++ b/apps/campfire/src/App.jsx
@@ -45,7 +45,7 @@ import useTheme from "./useTheme";
 import debugLog from "./utils/debugLog";
 import useSiteSettings from "./useSiteSettings";
 import useAgencyTheme from "./useAgencyTheme";
-import FullScreenSpinner from "./FullScreenSpinner";
+import LoadingOverlay from "./LoadingOverlay";
 import { DEFAULT_LOGO_URL } from "./constants";
 
 // Use HashRouter when the app is opened from the filesystem so routes work
@@ -130,9 +130,6 @@ const App = () => {
   }, [ready]);
 
 
-  if (!ready) {
-    return <FullScreenSpinner />;
-  }
 
   const signedIn = user && !user.isAnonymous;
   const role = isAdmin ? 'admin' : dbRole;
@@ -152,8 +149,9 @@ const App = () => {
   }
 
   return (
-    <RouterImpl basename={import.meta.env.BASE_URL}>
-      <ThemeWatcher />
+    <LoadingOverlay visible={!ready}>
+      <RouterImpl basename={import.meta.env.BASE_URL}>
+        <ThemeWatcher />
       <RequireMfa user={user} role={role}>
         <div className="min-h-screen flex">
           {signedIn && (
@@ -589,6 +587,7 @@ const App = () => {
         </div>
       </RequireMfa>
       </RouterImpl>
+    </LoadingOverlay>
   );
 };
 

--- a/apps/campfire/src/LoadingOverlay.jsx
+++ b/apps/campfire/src/LoadingOverlay.jsx
@@ -1,14 +1,26 @@
 import React from 'react';
 
-const LoadingOverlay = ({ visible = true, text = 'Loading...', className = '' }) => {
-  if (!visible) return null;
+const LoadingOverlay = ({
+  visible = true,
+  text = 'Loading...',
+  className = '',
+  children,
+}) => {
   return (
-    <div className={`loading-overlay ${className}`.trim()} data-testid="loading-overlay">
-      <div className="flex flex-col items-center space-y-4">
-        <div className="loading-ring" />
-        {text && <div>{text}</div>}
-      </div>
-    </div>
+    <>
+      {children}
+      {visible && (
+        <div
+          className={`loading-overlay ${className}`.trim()}
+          data-testid="loading-overlay"
+        >
+          <div className="flex flex-col items-center space-y-4">
+            <div className="loading-ring" />
+            {text && <div>{text}</div>}
+          </div>
+        </div>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- allow `LoadingOverlay` to wrap child components
- render app content inside `LoadingOverlay` so spinner disappears correctly

## Testing
- `pnpm test -r` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_683d13b85fb483318d00e15afa9eb68f