### PR TITLE
Fix loading overlay logic in Campfire app

### DIFF
--- a/apps/campfire/src/App.jsx
+++ b/apps/campfire/src/App.jsx
@@ -148,8 +148,11 @@ const App = () => {
     );
   }
 
+  if (!ready) {
+    return <LoadingOverlay visible />;
+  }
+
   return (
-    <LoadingOverlay visible={!ready}>
       <RouterImpl basename={import.meta.env.BASE_URL}>
         <ThemeWatcher />
       <RequireMfa user={user} role={role}>
@@ -587,7 +590,6 @@ const App = () => {
         </div>
       </RequireMfa>
       </RouterImpl>
-    </LoadingOverlay>
   );
 };
 


### PR DESCRIPTION
## Summary
- render `LoadingOverlay` only during load phase

## Testing
- `pnpm --filter campfire test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.11.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_683d1a7ec8808331a3b9a09cd6dc93ea