### PR TITLE
Add Firestore management API and CLAUDE.md

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "next-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,142 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+- `npm run dev` — Start Next.js dev server
+- `npm run build` — Production build
+- `npm run start` — Start production server
+- `npm run lint` — Run ESLint
+
+No test suite is configured.
+
+## Architecture
+
+**Next.js 14 App Router** site for Studio Tak with a **Refine.dev admin panel**, **Firestore** as the data layer, and **Ghost CMS** for blog content.
+
+### Data Flow
+
+Pages are stored in Firestore as documents with a `blocks` array. Each block defines a section type (hero, thirds, split, features, etc.). Components (reusable feature items) are stored separately and merged into blocks at render time via `lib/pageContent.ts`. When Firebase is unavailable, seed data from `lib/admin/pages.ts` and `lib/admin/components.ts` is used as fallback.
+
+Ghost CMS provides blog/article content at `/learn/`. Articles are fetched via the Ghost Content API (`lib/ghost.ts`) and rendered with `dangerouslySetInnerHTML`.
+
+### Routing
+
+- `/` — Home page (`app/page.tsx`)
+- `/learn/` — Ghost CMS article listing with tag filtering
+- `/learn/[slug]/` — Individual Ghost article
+- `/[...slug]/` — Dynamic catch-all for Firestore-backed marketing pages (supports redirects)
+- `/admin/` — Refine.dev admin panel behind `app/admin/(protected)/` route group
+
+All public pages use ISR with `revalidate = 120` and `dynamic = "force-static"`.
+
+### Block System
+
+`BlocksRenderer` in `components/sections/` maps block types to section components. Block types include: `hero`, `thirds`, `story`, `split`, `animated_headline`, `features`, `scroll_gallery`, `article_featured`, `article_grid`, `divider`. Blocks reference components by ID which are fetched and injected separately.
+
+### Admin Panel
+
+Refine.dev CRUD at `/admin/` manages pages, components, navigation, media, and site settings. Custom Firestore data providers live in `lib/admin/`. Auth is handled via `AdminAuthGate` with a local dev bypass (`lib/localAuthBypass.ts`, disabled in production).
+
+### Styling
+
+Global CSS with custom properties in `app/globals.css` (no Tailwind). Rubik font via Google Fonts. The `@next/next/no-img-element` ESLint rule is disabled — bare `<img>` tags are used intentionally.
+
+### Path Aliases
+
+- `@/components/*` → `components/*`
+- `@/lib/*` → `lib/*`
+
+## Environment Variables
+
+**Firebase**: `NEXT_PUBLIC_FIREBASE_API_KEY`, `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN`, `NEXT_PUBLIC_FIREBASE_PROJECT_ID`, `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET`, `NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID`, `NEXT_PUBLIC_FIREBASE_APP_ID`
+
+**Ghost CMS**: `GHOST_CONTENT_URL`, `GHOST_CONTENT_API_KEY`
+
+**Analytics**: `NEXT_PUBLIC_GA_MEASUREMENT_ID`, `NEXT_PUBLIC_SITE_URL` (default: `https://studiotak.co`)
+
+**Admin**: `SEED_TOKEN` (for admin API endpoints — optional, if unset all requests are allowed)
+
+## Content Management API
+
+REST endpoints at `/api/admin/` for programmatic page and component management. Auth via `Authorization: Bearer $SEED_TOKEN` header (skipped if `SEED_TOKEN` is unset). Shared helpers in `lib/adminApi.ts`.
+
+### Pages
+
+```bash
+# List all pages (optional ?status=published|draft)
+curl http://localhost:3000/api/admin/pages
+
+# Create a page
+curl -X POST http://localhost:3000/api/admin/pages \
+  -H "Content-Type: application/json" \
+  -d '{"id":"services","slug":"/services","title":"Services","status":"draft","blocks":[{"id":"svc-hero","type":"hero","title":"Our Services","alignment":"centered"}]}'
+
+# Get a single page
+curl http://localhost:3000/api/admin/pages/services
+
+# Full update
+curl -X PUT http://localhost:3000/api/admin/pages/services \
+  -H "Content-Type: application/json" \
+  -d '{"slug":"/services","title":"Services","status":"published","blocks":[...]}'
+
+# Partial update (e.g. publish)
+curl -X PATCH http://localhost:3000/api/admin/pages/services \
+  -H "Content-Type: application/json" \
+  -d '{"status":"published"}'
+
+# Delete
+curl -X DELETE http://localhost:3000/api/admin/pages/services
+```
+
+### Components
+
+```bash
+# List all components
+curl http://localhost:3000/api/admin/components
+
+# Create a component
+curl -X POST http://localhost:3000/api/admin/components \
+  -H "Content-Type: application/json" \
+  -d '{"id":"feature-analytics","kind":"feature","title":"Analytics","body":"Real-time dashboards."}'
+
+# Get / PUT / PATCH / DELETE at /api/admin/components/:id
+```
+
+### Response Shape
+
+All endpoints return `{ data: T }` for single items, `{ data: T[], total: number }` for lists, or `{ error: string }` on failure. Write operations auto-set `updatedAt` and call `revalidatePath()` for immediate ISR refresh.
+
+### Page Data Model
+
+Pages require `id` + `slug`. Key fields: `title`, `status` ("draft"|"published"), `blocks` array, SEO fields (`seoTitle`, `metaDescription`, `canonicalUrl`, `ogTitle`, `ogDescription`). See `PageRecord` in `lib/admin/pages.ts` for the full type.
+
+### Block Types
+
+Each block needs `id` + `type`. Full type definitions in `lib/admin/pages.ts`. Rendered by `BlocksRenderer` in `components/sections/`.
+
+| Block | Visual | When to use | Key fields |
+|-------|--------|-------------|------------|
+| `hero` | Full-bleed intro with optional background image/video, overlay, and two CTAs. Can run in "dynamic" mode with animated media columns. | Page openings, landing pages | `title`, `subtitle`, `alignment` ("centered"\|"image_left"\|"image_right"), `primaryCtaLabel`/`Href`, `media`, `background`, `mode` ("static"\|"dynamic") |
+| `thirds` | Compact variant of hero — same layout but less padding, no border, transparent background. | Secondary hero-style sections, mid-page callouts | Same as hero plus `layout` ("left"\|"centered") |
+| `story` | Narrative section with heading, body, optional media, and expandable subsections grid. Three variants. | About sections, case studies, process steps | `heading`, `body`, `variant` ("single_column"\|"two_column"\|"split_with_quote"), `sections[]` ({title, body}) |
+| `split` | Two-column: text on one side, square media on the other. Optional CTA. | Feature highlights, content + image pairs | `heading`, `body`, `media`, `mediaSide` ("left"\|"right"), `ctaLabel`/`Href` |
+| `animated_headline` | Full-viewport animated text with motion effects. Freezeable on scroll. | Dramatic section breaks, storytelling beats | `headline`, `subtext`, `animationStyle` ("fade_by_word"\|"slide_by_letter"\|"typewriter"\|"scramble"), `animationMode` ("viewport"\|"scroll") |
+| `features` | Horizontal gallery of feature cards with icons, titles, and descriptions. Full-bleed viewport width. | Capabilities, service offerings, feature lists | `heading`, `body`, `columns`, `items[]` ({title, body, badge, icon, componentId}) |
+| `scroll_gallery` | Horizontal carousel with left/right nav buttons and edge fade masks. Stacks on mobile. | Portfolio items, step-by-step processes, card showcases | `heading`, `body`, `items[]` (same as features) |
+| `showcase` | Overlapping card stack with staggered rotation angles. Loads media from Firebase by type/industry filter. | Project portfolios, impressive media galleries | `typeFilter`, `industryFilter`, `limit`, `featuredOnly`, `animationPreset` |
+| `logos` | Two-row continuously scrolling logo wall (opposite directions). Loads from Firebase. | Client logos, partner showcases | `heading`, `limit` |
+| `contact` | Two-column: embedded form (Brevo/Sendinblue) on left, square media on right. Includes email validation and success state. | Lead capture, contact forms, inquiries | `heading`, `body`, `formId`, `portalId`, `region`, `formScriptSrc`, `media` |
+| `article_featured` | Large featured article card (image + title + excerpt + "Read more"). Pulls from Ghost CMS. | Blog highlight at top of learn/news pages | `tagFilter` (optional Ghost tag) |
+| `article_grid` | Two-tier article listing: 3-column recent posts grid on top, auto-fit card grid below. Pulls from Ghost CMS. | Blog listing, knowledge base index | `tagFilter`, `offset`, `limit` |
+| `divider` | Simple horizontal rule. | Visual separator between sections | `width` ("full"\|"page") |
+
+**Common patterns:**
+- All blocks support `enableDarkModeOnScroll` to toggle dark theme as the user scrolls into view
+- Feature items in `features` and `scroll_gallery` blocks can reference components via `componentId` — the component's data (title, body, icon) overwrites the item at render time
+- `showcase` and `logos` blocks pull media from the Firebase `media` collection, not from inline data
+
+### Components Data Model
+
+Components require `id` + `kind` ("feature"). Fields: `title`, `body`, `icon` (BlockMedia), `industry`, `type`, `mediaFit`. Components are referenced from feature items in blocks via `componentId`.

--- a/app/api/admin/components/[id]/route.ts
+++ b/app/api/admin/components/[id]/route.ts
@@ -1,0 +1,96 @@
+import { NextResponse } from "next/server";
+import { isAuthorized, getDb, stripUndefined, unauthorized, missingFirebase, firebaseConfigured } from "@/lib/adminApi";
+import { normalizeComponentShape, type ComponentRecord } from "@/lib/admin/components";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+async function getComponentDoc(id: string) {
+  const db = getDb();
+  const snapshot = await db.collection("components").doc(id).get();
+  if (!snapshot.exists) return null;
+  return normalizeComponentShape({ id: snapshot.id, ...snapshot.data() });
+}
+
+export async function GET(request: Request, context: RouteContext) {
+  if (!isAuthorized(request)) return unauthorized();
+  if (!firebaseConfigured()) return missingFirebase();
+
+  try {
+    const { id } = await context.params;
+    const data = await getComponentDoc(id);
+    if (!data) return NextResponse.json({ error: "Component not found" }, { status: 404 });
+    return NextResponse.json({ data });
+  } catch (error) {
+    console.error("Failed to get component", error);
+    return NextResponse.json({ error: "Failed to get component" }, { status: 500 });
+  }
+}
+
+export async function PUT(request: Request, context: RouteContext) {
+  if (!isAuthorized(request)) return unauthorized();
+  if (!firebaseConfigured()) return missingFirebase();
+
+  try {
+    const { id } = await context.params;
+    const body = await request.json();
+    const db = getDb();
+
+    const component: ComponentRecord = {
+      ...body,
+      id,
+      updatedAt: new Date().toISOString()
+    };
+
+    await db.collection("components").doc(id).set(stripUndefined(component));
+
+    const data = await getComponentDoc(id);
+    return NextResponse.json({ data });
+  } catch (error) {
+    console.error("Failed to update component", error);
+    return NextResponse.json({ error: "Failed to update component" }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  if (!isAuthorized(request)) return unauthorized();
+  if (!firebaseConfigured()) return missingFirebase();
+
+  try {
+    const { id } = await context.params;
+    const body = await request.json();
+    const db = getDb();
+    const ref = db.collection("components").doc(id);
+
+    const existing = await ref.get();
+    if (!existing.exists) return NextResponse.json({ error: "Component not found" }, { status: 404 });
+
+    const updates = stripUndefined({ ...body, updatedAt: new Date().toISOString() });
+    await ref.update(updates);
+
+    const data = await getComponentDoc(id);
+    return NextResponse.json({ data });
+  } catch (error) {
+    console.error("Failed to patch component", error);
+    return NextResponse.json({ error: "Failed to patch component" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request, context: RouteContext) {
+  if (!isAuthorized(request)) return unauthorized();
+  if (!firebaseConfigured()) return missingFirebase();
+
+  try {
+    const { id } = await context.params;
+    const db = getDb();
+    const ref = db.collection("components").doc(id);
+
+    const existing = await ref.get();
+    if (!existing.exists) return NextResponse.json({ error: "Component not found" }, { status: 404 });
+
+    await ref.delete();
+    return NextResponse.json({ success: true, id });
+  } catch (error) {
+    console.error("Failed to delete component", error);
+    return NextResponse.json({ error: "Failed to delete component" }, { status: 500 });
+  }
+}

--- a/app/api/admin/components/route.ts
+++ b/app/api/admin/components/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { isAuthorized, getDb, stripUndefined, unauthorized, missingFirebase, firebaseConfigured } from "@/lib/adminApi";
+import { normalizeComponentShape, type ComponentRecord } from "@/lib/admin/components";
+
+export async function GET(request: Request) {
+  if (!isAuthorized(request)) return unauthorized();
+  if (!firebaseConfigured()) return missingFirebase();
+
+  try {
+    const db = getDb();
+    const snapshot = await db.collection("components").orderBy("title", "asc").get();
+    const data = snapshot.docs.map((docSnap) =>
+      normalizeComponentShape({ id: docSnap.id, ...docSnap.data() })
+    );
+    return NextResponse.json({ data, total: data.length });
+  } catch (error) {
+    console.error("Failed to list components", error);
+    return NextResponse.json({ error: "Failed to list components" }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  if (!isAuthorized(request)) return unauthorized();
+  if (!firebaseConfigured()) return missingFirebase();
+
+  try {
+    const body = await request.json();
+    if (!body.id || !body.kind) {
+      return NextResponse.json({ error: "id and kind are required" }, { status: 400 });
+    }
+
+    const db = getDb();
+    const component: ComponentRecord = {
+      ...body,
+      updatedAt: new Date().toISOString()
+    };
+
+    const ref = db.collection("components").doc(component.id);
+    await ref.set(stripUndefined(component));
+
+    const snapshot = await ref.get();
+    const data = normalizeComponentShape({ id: snapshot.id, ...snapshot.data() });
+
+    return NextResponse.json({ data }, { status: 201 });
+  } catch (error) {
+    console.error("Failed to create component", error);
+    return NextResponse.json({ error: "Failed to create component" }, { status: 500 });
+  }
+}

--- a/app/api/admin/pages/[id]/route.ts
+++ b/app/api/admin/pages/[id]/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import { isAuthorized, getDb, stripUndefined, unauthorized, missingFirebase, firebaseConfigured } from "@/lib/adminApi";
+import { normalizePageShape } from "@/lib/pageContent";
+import type { PageRecord } from "@/lib/admin/pages";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+async function getPageDoc(id: string) {
+  const db = getDb();
+  const snapshot = await db.collection("pages").doc(id).get();
+  if (!snapshot.exists) return null;
+  return normalizePageShape({ id: snapshot.id, ...snapshot.data() });
+}
+
+export async function GET(request: Request, context: RouteContext) {
+  if (!isAuthorized(request)) return unauthorized();
+  if (!firebaseConfigured()) return missingFirebase();
+
+  try {
+    const { id } = await context.params;
+    const data = await getPageDoc(id);
+    if (!data) return NextResponse.json({ error: "Page not found" }, { status: 404 });
+    return NextResponse.json({ data });
+  } catch (error) {
+    console.error("Failed to get page", error);
+    return NextResponse.json({ error: "Failed to get page" }, { status: 500 });
+  }
+}
+
+export async function PUT(request: Request, context: RouteContext) {
+  if (!isAuthorized(request)) return unauthorized();
+  if (!firebaseConfigured()) return missingFirebase();
+
+  try {
+    const { id } = await context.params;
+    const body = await request.json();
+    const db = getDb();
+
+    const page: PageRecord = {
+      ...body,
+      id,
+      status: body.status ?? "draft",
+      blocks: body.blocks ?? [],
+      updatedAt: new Date().toISOString()
+    };
+
+    await db.collection("pages").doc(id).set(stripUndefined(page));
+
+    const data = await getPageDoc(id);
+    if (page.slug) revalidatePath(page.slug);
+    revalidatePath("/");
+
+    return NextResponse.json({ data });
+  } catch (error) {
+    console.error("Failed to update page", error);
+    return NextResponse.json({ error: "Failed to update page" }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  if (!isAuthorized(request)) return unauthorized();
+  if (!firebaseConfigured()) return missingFirebase();
+
+  try {
+    const { id } = await context.params;
+    const body = await request.json();
+    const db = getDb();
+    const ref = db.collection("pages").doc(id);
+
+    const existing = await ref.get();
+    if (!existing.exists) return NextResponse.json({ error: "Page not found" }, { status: 404 });
+
+    const updates = stripUndefined({ ...body, updatedAt: new Date().toISOString() });
+    await ref.update(updates);
+
+    const data = await getPageDoc(id);
+    const slug = data?.slug ?? existing.data()?.slug;
+    if (slug) revalidatePath(slug as string);
+    revalidatePath("/");
+
+    return NextResponse.json({ data });
+  } catch (error) {
+    console.error("Failed to patch page", error);
+    return NextResponse.json({ error: "Failed to patch page" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request, context: RouteContext) {
+  if (!isAuthorized(request)) return unauthorized();
+  if (!firebaseConfigured()) return missingFirebase();
+
+  try {
+    const { id } = await context.params;
+    const db = getDb();
+    const ref = db.collection("pages").doc(id);
+
+    const existing = await ref.get();
+    if (!existing.exists) return NextResponse.json({ error: "Page not found" }, { status: 404 });
+
+    const slug = existing.data()?.slug;
+    await ref.delete();
+
+    if (slug) revalidatePath(slug as string);
+    revalidatePath("/");
+
+    return NextResponse.json({ success: true, id });
+  } catch (error) {
+    console.error("Failed to delete page", error);
+    return NextResponse.json({ error: "Failed to delete page" }, { status: 500 });
+  }
+}

--- a/app/api/admin/pages/route.ts
+++ b/app/api/admin/pages/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import { isAuthorized, getDb, stripUndefined, unauthorized, missingFirebase, firebaseConfigured } from "@/lib/adminApi";
+import { normalizePageShape } from "@/lib/pageContent";
+import type { PageRecord } from "@/lib/admin/pages";
+
+export async function GET(request: Request) {
+  if (!isAuthorized(request)) return unauthorized();
+  if (!firebaseConfigured()) return missingFirebase();
+
+  try {
+    const db = getDb();
+    const url = new URL(request.url);
+    const status = url.searchParams.get("status");
+
+    let q: FirebaseFirestore.Query = db.collection("pages").orderBy("title", "asc");
+    if (status) {
+      q = db.collection("pages").where("status", "==", status).orderBy("title", "asc");
+    }
+
+    const snapshot = await q.get();
+    const data = snapshot.docs.map((docSnap) =>
+      normalizePageShape({ id: docSnap.id, ...docSnap.data() })
+    );
+    return NextResponse.json({ data, total: data.length });
+  } catch (error) {
+    console.error("Failed to list pages", error);
+    return NextResponse.json({ error: "Failed to list pages" }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  if (!isAuthorized(request)) return unauthorized();
+  if (!firebaseConfigured()) return missingFirebase();
+
+  try {
+    const body = await request.json();
+    if (!body.id || !body.slug) {
+      return NextResponse.json({ error: "id and slug are required" }, { status: 400 });
+    }
+
+    const db = getDb();
+    const page: PageRecord = {
+      ...body,
+      status: body.status ?? "draft",
+      blocks: body.blocks ?? [],
+      updatedAt: new Date().toISOString()
+    };
+
+    const ref = db.collection("pages").doc(page.id);
+    await ref.set(stripUndefined(page));
+
+    const snapshot = await ref.get();
+    const data = normalizePageShape({ id: snapshot.id, ...snapshot.data() });
+
+    revalidatePath(page.slug);
+    revalidatePath("/");
+
+    return NextResponse.json({ data }, { status: 201 });
+  } catch (error) {
+    console.error("Failed to create page", error);
+    return NextResponse.json({ error: "Failed to create page" }, { status: 500 });
+  }
+}

--- a/lib/adminApi.ts
+++ b/lib/adminApi.ts
@@ -1,0 +1,63 @@
+import { initializeApp, getApps, cert, type App } from "firebase-admin/app";
+import { getFirestore, type Firestore } from "firebase-admin/firestore";
+
+let adminApp: App | undefined;
+
+function getAdminApp(): App {
+  if (adminApp) return adminApp;
+  const existing = getApps();
+  if (existing.length > 0) {
+    adminApp = existing[0];
+    return adminApp;
+  }
+
+  const serviceAccountJson = process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+  if (serviceAccountJson) {
+    const serviceAccount = JSON.parse(serviceAccountJson);
+    adminApp = initializeApp({ credential: cert(serviceAccount) });
+  } else {
+    // Falls back to Application Default Credentials or project ID
+    adminApp = initializeApp({
+      projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID
+    });
+  }
+  return adminApp;
+}
+
+export function getDb(): Firestore {
+  return getFirestore(getAdminApp());
+}
+
+export function isAuthorized(request: Request): boolean {
+  const token = process.env.SEED_TOKEN;
+  if (!token) return true;
+  const header = request.headers.get("authorization") ?? "";
+  const bearer = header.startsWith("Bearer ") ? header.replace("Bearer ", "") : null;
+  return bearer === token;
+}
+
+export function stripUndefined<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => stripUndefined(item)) as unknown as T;
+  }
+  if (value && typeof value === "object") {
+    return Object.entries(value as Record<string, any>).reduce((acc, [key, val]) => {
+      if (val === undefined) return acc;
+      (acc as any)[key] = stripUndefined(val);
+      return acc;
+    }, {} as any) as T;
+  }
+  return value;
+}
+
+export function unauthorized() {
+  return Response.json({ error: "Unauthorized" }, { status: 401 });
+}
+
+export function missingFirebase() {
+  return Response.json({ error: "Firebase not configured" }, { status: 400 });
+}
+
+export function firebaseConfigured(): boolean {
+  return !!(process.env.FIREBASE_SERVICE_ACCOUNT_JSON || process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID);
+}


### PR DESCRIPTION
## Summary
- **REST API for pages & components**: New endpoints at `/api/admin/pages` and `/api/admin/components` for full CRUD operations against Firestore, enabling programmatic content management
- **CLAUDE.md**: Comprehensive project documentation including block type reference, API usage examples, and architecture overview so Claude can autonomously create and manage pages
- **Dev server config**: Added `.claude/launch.json` for preview integration

## Test plan
- [ ] Verify `npm run build` succeeds
- [ ] Test API endpoints locally: `GET /api/admin/pages`, `POST /api/admin/pages`, etc.
- [ ] Confirm existing admin UI still works alongside new API
- [ ] Verify ISR revalidation triggers on write operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)