### PR TITLE
feat: add page inspect API and dev data source banner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,3 +156,61 @@ Tag maps are in `app/learn/[slug]/page.tsx` (`CAMPFIRE_PAGE_TAGS`, `CAMPFIRE_AUD
 ### Components Data Model
 
 Components require `id` + `kind` ("feature"). Fields: `title`, `body`, `icon` (BlockMedia), `industry`, `type`, `mediaFit`. Components are referenced from feature items in blocks via `componentId`.
+
+## Content Update Workflow
+
+**IMPORTANT: Firestore is the source of truth.** When Firebase is configured, the dev server and production site read from Firestore. Seed data in `lib/admin/pages.ts` is only a build-time fallback.
+
+### Quick Decision Tree
+
+1. **Editing an existing page?** → Use `PATCH /api/admin/pages/:id` with only the changed fields. Done.
+2. **Replacing all blocks on a page?** → Use `PUT /api/admin/pages/:id` with the full page object. Done.
+3. **Creating a new page?** → Use `POST /api/admin/pages` with full page data. Done.
+4. **Need seed data in sync for deploys?** → First `GET /api/admin/seed?collection=pages` to pull live state, then update the seed file.
+5. **NEVER edit seed data as the primary update method** — edit Firestore via the API, then optionally sync seed data afterward.
+
+### Inspecting Page Structure
+
+Use the inspect endpoint to see what blocks are on any page and where the data comes from:
+
+```bash
+# Inspect by slug (most common)
+curl http://localhost:3000/api/admin/inspect?slug=/
+
+# Inspect by page ID
+curl http://localhost:3000/api/admin/inspect?id=home
+```
+
+Returns a compact summary:
+```json
+{
+  "source": "firestore",
+  "page": { "id": "home", "slug": "/", "title": "Home", "status": "published" },
+  "blockCount": 8,
+  "blockSequence": "hero → animated_headline → features → split → logos → contact",
+  "blocks": [ { "id": "...", "type": "hero", "title": "..." }, ... ]
+}
+```
+
+The `source` field tells you whether data came from `"firestore"` or `"seed"` fallback.
+
+### Dev-Mode Data Source Banner
+
+In development, a small fixed banner appears in the bottom-right corner of every page showing:
+- **Source**: FIRESTORE (green) or SEED (amber) or NOT_FOUND (red)
+- **Block sequence**: compact list of block types on the page
+- **Last updated**: timestamp
+
+Click the banner to dismiss it. It only renders in development (`NODE_ENV !== "production"`).
+
+### Verifying Changes
+
+After making an API update:
+1. Call the inspect endpoint to confirm the data was written correctly
+2. Reload the page — ISR revalidation happens automatically on writes
+3. Use `preview_snapshot` to verify the rendered output if needed
+
+### Common Pitfalls
+- **Seeing old data?** The dev server may have a cached ISR page. API writes call `revalidatePath()` automatically, but you may need to reload.
+- **Seed data showing instead of Firestore?** Check that Firebase env vars are set. The inspect endpoint's `source` field confirms this.
+- **Don't read seed files to understand page content** — use the inspect endpoint instead. Seed files may be stale.

--- a/app/api/admin/inspect/route.ts
+++ b/app/api/admin/inspect/route.ts
@@ -1,0 +1,180 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isAuthorized, getDb, unauthorized, firebaseConfigured } from "@/lib/adminApi";
+import { normalizeSlugPath } from "@/lib/pageContent";
+import { seedPages } from "@/lib/admin/pages";
+import type { BlockRecord, PageRecord } from "@/lib/admin/pages";
+
+/**
+ * GET /api/admin/inspect?slug=/some-page
+ *
+ * Returns a compact summary of a page's block structure and data source.
+ * Designed for Claude Code to quickly understand what's on a page
+ * without reading seed files or taking screenshots.
+ */
+
+function summarizeBlock(block: BlockRecord): Record<string, unknown> {
+  const summary: Record<string, unknown> = {
+    id: block.id,
+    type: block.type,
+  };
+
+  if (block.adminLabel) summary.adminLabel = block.adminLabel;
+
+  switch (block.type) {
+    case "hero":
+    case "thirds":
+      summary.title = block.title;
+      summary.alignment = block.alignment;
+      summary.mode = block.mode;
+      if (block.primaryCtaLabel) summary.cta = block.primaryCtaLabel;
+      break;
+    case "story":
+      summary.heading = block.heading;
+      summary.variant = block.variant;
+      if (block.sections?.length) summary.sectionCount = block.sections.length;
+      break;
+    case "split":
+      summary.heading = block.heading;
+      summary.mediaSide = block.mediaSide;
+      if (block.ctaLabel) summary.cta = block.ctaLabel;
+      break;
+    case "animated_headline":
+      summary.headline = block.headline;
+      summary.animationStyle = block.animationStyle;
+      break;
+    case "features":
+    case "scroll_gallery":
+    case "feature_spotlight":
+      summary.heading = block.heading;
+      summary.itemCount = block.items?.length ?? 0;
+      if (block.type === "features" && "variant" in block) summary.variant = (block as any).variant;
+      break;
+    case "stats":
+      summary.heading = block.heading;
+      summary.itemCount = block.items?.length ?? 0;
+      summary.variant = block.variant;
+      break;
+    case "comparison":
+      summary.heading = block.heading;
+      break;
+    case "showcase":
+      summary.typeFilter = block.typeFilter;
+      summary.industryFilter = block.industryFilter;
+      break;
+    case "logos":
+      summary.heading = block.heading;
+      break;
+    case "contact":
+      summary.heading = block.heading;
+      break;
+    case "article_featured":
+    case "article_grid":
+      summary.tagFilter = block.tagFilter;
+      break;
+    case "divider":
+      summary.width = block.width;
+      break;
+  }
+
+  if (block.enableDarkModeOnScroll) summary.darkMode = true;
+
+  return summary;
+}
+
+export async function GET(request: NextRequest) {
+  if (!isAuthorized(request)) return unauthorized();
+
+  const slug = request.nextUrl.searchParams.get("slug");
+  const id = request.nextUrl.searchParams.get("id");
+
+  if (!slug && !id) {
+    return NextResponse.json(
+      { error: "Provide ?slug=/path or ?id=pageId" },
+      { status: 400 }
+    );
+  }
+
+  let source: "firestore" | "seed" | "not_found" = "not_found";
+  let page: PageRecord | null = null;
+
+  // Try Firestore first
+  if (firebaseConfigured()) {
+    try {
+      const db = getDb();
+      if (id) {
+        const doc = await db.collection("pages").doc(id).get();
+        if (doc.exists) {
+          page = { id: doc.id, ...doc.data() } as PageRecord;
+          source = "firestore";
+        }
+      } else if (slug) {
+        const normalized = normalizeSlugPath(slug);
+        const snapshot = await db
+          .collection("pages")
+          .where("slug", "==", normalized)
+          .limit(1)
+          .get();
+
+        if (!snapshot.empty) {
+          const doc = snapshot.docs[0];
+          page = { id: doc.id, ...doc.data() } as PageRecord;
+          source = "firestore";
+        } else {
+          // Try without leading slash
+          const withoutLeading = normalized.startsWith("/") ? normalized.slice(1) : normalized;
+          const altSnapshot = await db
+            .collection("pages")
+            .where("slug", "==", withoutLeading)
+            .limit(1)
+            .get();
+          if (!altSnapshot.empty) {
+            const doc = altSnapshot.docs[0];
+            page = { id: doc.id, ...doc.data() } as PageRecord;
+            source = "firestore";
+          }
+        }
+      }
+    } catch (error) {
+      console.error("Inspect: Firestore query failed, falling back to seed", error);
+    }
+  }
+
+  // Fallback to seed data
+  if (!page) {
+    const normalized = slug ? normalizeSlugPath(slug) : null;
+    const seedPage = id
+      ? seedPages.find((p) => p.id === id)
+      : seedPages.find((p) => normalizeSlugPath(p.slug) === normalized);
+
+    if (seedPage) {
+      page = seedPage;
+      source = "seed";
+    }
+  }
+
+  if (!page) {
+    return NextResponse.json({
+      source: "not_found",
+      slug: slug ?? id,
+      error: "Page not found in Firestore or seed data"
+    }, { status: 404 });
+  }
+
+  const blocks = page.blocks ?? [];
+  const blockSummary = blocks.map(summarizeBlock);
+  const blockTypes = blocks.map((b) => b.type);
+
+  return NextResponse.json({
+    source,
+    page: {
+      id: page.id,
+      slug: page.slug,
+      title: page.title,
+      status: page.status,
+      updatedAt: page.updatedAt,
+    },
+    blockCount: blocks.length,
+    blockSequence: blockTypes.join(" → "),
+    blocks: blockSummary,
+  });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Rubik } from "next/font/google";
 import Script from "next/script";
 import { getSiteSettings } from "@/lib/siteSettings";
+import { DevDataSourceBanner } from "@/components/DevDataSourceBanner";
 import "./globals.css";
 
 const rubik = Rubik({
@@ -64,6 +65,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           </>
         ) : null}
         {children}
+        <DevDataSourceBanner />
       </body>
     </html>
   );

--- a/components/DevDataSourceBanner.tsx
+++ b/components/DevDataSourceBanner.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Dev-only banner that shows whether the current page is rendering
+ * from Firestore or seed fallback data.
+ *
+ * Only renders when NODE_ENV !== "production".
+ * Calls /api/admin/inspect?slug=<current path> on mount.
+ */
+
+interface InspectResult {
+  source: "firestore" | "seed" | "not_found";
+  page?: { id: string; title: string; updatedAt?: string };
+  blockCount?: number;
+  blockSequence?: string;
+}
+
+export function DevDataSourceBanner() {
+  const [info, setInfo] = useState<InspectResult | null>(null);
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") return;
+
+    const slug = window.location.pathname;
+    fetch(`/api/admin/inspect?slug=${encodeURIComponent(slug)}`)
+      .then((res) => res.json())
+      .then((data) => setInfo(data))
+      .catch(() => setInfo({ source: "not_found" }));
+  }, []);
+
+  if (process.env.NODE_ENV === "production") return null;
+  if (!info || !visible) return null;
+
+  const colors: Record<string, { bg: string; text: string }> = {
+    firestore: { bg: "#065f46", text: "#d1fae5" },
+    seed: { bg: "#92400e", text: "#fef3c7" },
+    not_found: { bg: "#991b1b", text: "#fecaca" },
+  };
+
+  const { bg, text } = colors[info.source] ?? colors.not_found;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        bottom: 8,
+        right: 8,
+        zIndex: 99999,
+        background: bg,
+        color: text,
+        padding: "6px 12px",
+        borderRadius: 6,
+        fontSize: 12,
+        fontFamily: "monospace",
+        lineHeight: 1.4,
+        maxWidth: 360,
+        boxShadow: "0 2px 8px rgba(0,0,0,0.3)",
+        cursor: "pointer",
+      }}
+      onClick={() => setVisible(false)}
+      title="Click to dismiss"
+    >
+      <div style={{ fontWeight: 700 }}>
+        Source: {info.source.toUpperCase()}
+      </div>
+      {info.blockCount != null && (
+        <div style={{ opacity: 0.85, marginTop: 2 }}>
+          {info.blockCount} blocks: {info.blockSequence}
+        </div>
+      )}
+      {info.page?.updatedAt && (
+        <div style={{ opacity: 0.7, marginTop: 2 }}>
+          Updated: {new Date(info.page.updatedAt).toLocaleString()}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Helps Claude Code (and developers) quickly understand page structure and data source without reading seed files or scrolling screenshots.

- /api/admin/inspect?slug= returns block structure + source (firestore/seed)
- DevDataSourceBanner shows source indicator in dev mode (bottom-right)
- CLAUDE.md updated with content update workflow and decision tree