### PR TITLE
Fix dev banner to show actual data source, not stale inspect API

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "next-dev",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
-      "port": 3000
+      "port": 3000,
+      "autoPort": true
     }
   ]
 }

--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -3,8 +3,9 @@ import { notFound, redirect, permanentRedirect } from "next/navigation";
 import { SiteHeader } from "@/components/SiteHeader";
 import { SiteFooter } from "@/components/SiteFooter";
 import { BlocksRenderer } from "@/components/sections/BlocksRenderer";
+import { DevDataSourceBanner } from "@/components/DevDataSourceBanner";
 import { getNavigationItems } from "@/lib/navigation";
-import { getPublishedPageBySlug, getPublishedPages, normalizeSlugPath } from "@/lib/pageContent";
+import { getPublishedPageBySlug, getPublishedPageBySlugWithSource, getPublishedPages, normalizeSlugPath } from "@/lib/pageContent";
 
 export const revalidate = 120;
 export const dynamic = "force-static";
@@ -54,7 +55,7 @@ export async function generateMetadata({ params }: PageParams): Promise<Metadata
 
 export default async function MarketingPage({ params }: PageParams) {
   const slugPath = normalizeSlugPath(slugToPath(params.slug));
-  const page = await getPublishedPageBySlug(slugPath);
+  const { page, source } = await getPublishedPageBySlugWithSource(slugPath);
 
   if (!page) {
     const pages = await getPublishedPages();
@@ -96,6 +97,8 @@ export default async function MarketingPage({ params }: PageParams) {
   const pagePaddingTop = hasHeroFirst ? 0 : 72;
   const pagePaddingBottom = hasHeroFirst ? 0 : 120;
   const navItems = await getNavigationItems();
+  const blocks = page.blocks ?? [];
+  const blockSequence = blocks.map((b) => b.type).join(" → ");
 
   return (
     <main>
@@ -108,7 +111,7 @@ export default async function MarketingPage({ params }: PageParams) {
           gap: 32
         }}
       >
-        <BlocksRenderer blocks={page.blocks} />
+        <BlocksRenderer blocks={blocks} />
         {jsonLd ? (
           <script
             type="application/ld+json"
@@ -117,6 +120,13 @@ export default async function MarketingPage({ params }: PageParams) {
         ) : null}
       </div>
       <SiteFooter navItems={navItems} />
+      <DevDataSourceBanner
+        source={source}
+        blockSequence={blockSequence}
+        blockCount={blocks.length}
+        pageStatus={page.status}
+        updatedAt={page.updatedAt}
+      />
     </main>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { Rubik } from "next/font/google";
 import Script from "next/script";
 import { getSiteSettings } from "@/lib/siteSettings";
-import { DevDataSourceBanner } from "@/components/DevDataSourceBanner";
 import "./globals.css";
 
 const rubik = Rubik({
@@ -65,7 +64,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           </>
         ) : null}
         {children}
-        <DevDataSourceBanner />
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,19 +1,22 @@
 import { SiteHeader } from "@/components/SiteHeader";
 import { SiteFooter } from "@/components/SiteFooter";
 import { BlocksRenderer } from "@/components/sections/BlocksRenderer";
+import { DevDataSourceBanner } from "@/components/DevDataSourceBanner";
 import { getNavigationItems } from "@/lib/navigation";
-import { getPublishedPageBySlug } from "@/lib/pageContent";
+import { getPublishedPageBySlugWithSource } from "@/lib/pageContent";
 
 export const revalidate = 120;
 export const dynamic = "force-static";
 
 export default async function HomePage() {
-  const pageData = await getPublishedPageBySlug("/");
+  const { page: pageData, source } = await getPublishedPageBySlugWithSource("/");
   const navItems = await getNavigationItems();
   const blocks = pageData?.blocks ?? [];
   const hasHeroFirst = blocks[0]?.type === "hero" || blocks[0]?.type === "thirds";
   const pagePaddingTop = hasHeroFirst ? 0 : 72;
   const pagePaddingBottom = hasHeroFirst ? 0 : 120;
+
+  const blockSequence = blocks.map((b) => b.type).join(" → ");
 
   return (
     <main>
@@ -29,6 +32,13 @@ export default async function HomePage() {
         {blocks.length ? <BlocksRenderer blocks={blocks} /> : null}
       </div>
       <SiteFooter navItems={navItems} />
+      <DevDataSourceBanner
+        source={source}
+        blockSequence={blockSequence}
+        blockCount={blocks.length}
+        pageStatus={pageData?.status}
+        updatedAt={pageData?.updatedAt}
+      />
     </main>
   );
 }

--- a/components/DevDataSourceBanner.tsx
+++ b/components/DevDataSourceBanner.tsx
@@ -1,39 +1,31 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import type { PageDataSource } from "@/lib/pageContent";
 
 /**
  * Dev-only banner that shows whether the current page is rendering
  * from Firestore or seed fallback data.
  *
+ * Receives data source info as props from the server component
+ * so it always reflects the ACTUAL render source (not a separate API call).
+ *
  * Only renders when NODE_ENV !== "production".
- * Calls /api/admin/inspect?slug=<current path> on mount.
  */
 
-interface InspectResult {
-  source: "firestore" | "seed" | "not_found";
-  page?: { id: string; title: string; status?: string; updatedAt?: string };
-  warnings?: string[];
-  blockCount?: number;
-  blockSequence?: string;
+interface Props {
+  source: PageDataSource;
+  blockSequence: string;
+  blockCount: number;
+  pageStatus?: string;
+  updatedAt?: string;
 }
 
-export function DevDataSourceBanner() {
-  const [info, setInfo] = useState<InspectResult | null>(null);
+export function DevDataSourceBanner({ source = "not_found", blockSequence, blockCount, pageStatus, updatedAt }: Props) {
   const [visible, setVisible] = useState(true);
 
-  useEffect(() => {
-    if (process.env.NODE_ENV === "production") return;
-
-    const slug = window.location.pathname;
-    fetch(`/api/admin/inspect?slug=${encodeURIComponent(slug)}`)
-      .then((res) => res.json())
-      .then((data) => setInfo(data))
-      .catch(() => setInfo({ source: "not_found" }));
-  }, []);
-
   if (process.env.NODE_ENV === "production") return null;
-  if (!info || !visible) return null;
+  if (!visible) return null;
 
   const colors: Record<string, { bg: string; text: string }> = {
     firestore: { bg: "#065f46", text: "#d1fae5" },
@@ -41,7 +33,15 @@ export function DevDataSourceBanner() {
     not_found: { bg: "#991b1b", text: "#fecaca" },
   };
 
-  const { bg, text } = colors[info.source] ?? colors.not_found;
+  const { bg, text } = colors[source] ?? colors.not_found;
+
+  const warnings: string[] = [];
+  if (pageStatus && pageStatus !== "published") {
+    warnings.push(`Page status is "${pageStatus}" — it will NOT render on the public site. Set status to "published" to make it visible.`);
+  }
+  if (source === "seed") {
+    warnings.push("Rendering from seed data. Seed blocks may not match Firestore.");
+  }
 
   return (
     <div
@@ -65,21 +65,21 @@ export function DevDataSourceBanner() {
       title="Click to dismiss"
     >
       <div style={{ fontWeight: 700 }}>
-        Source: {info.source.toUpperCase()}
+        Source: {source.toUpperCase()}
       </div>
-      {info.blockCount != null && (
+      {blockCount > 0 && (
         <div style={{ opacity: 0.85, marginTop: 2 }}>
-          {info.blockCount} blocks: {info.blockSequence}
+          {blockCount} blocks: {blockSequence}
         </div>
       )}
-      {info.warnings?.map((w, i) => (
+      {warnings.map((w, i) => (
         <div key={i} style={{ color: "#fca5a5", marginTop: 2, fontWeight: 600 }}>
           ⚠ {w}
         </div>
       ))}
-      {info.page?.updatedAt && (
+      {updatedAt && (
         <div style={{ opacity: 0.7, marginTop: 2 }}>
-          Updated: {new Date(info.page.updatedAt).toLocaleString()}
+          Updated: {new Date(updatedAt).toLocaleString()}
         </div>
       )}
     </div>

--- a/lib/pageContent.ts
+++ b/lib/pageContent.ts
@@ -252,17 +252,25 @@ export const normalizeSlugPath = (slug: string): string => {
   return withoutTrailingSlash || "/";
 };
 
-export async function getPublishedPageBySlug(
+export type PageDataSource = "firestore" | "seed" | "not_found";
+
+export interface PageWithSource {
+  page: PageRecord | null;
+  source: PageDataSource;
+}
+
+export async function getPublishedPageBySlugWithSource(
   slug: string,
   options?: { tagFilter?: string | null }
-): Promise<PageRecord | null> {
+): Promise<PageWithSource> {
   const normalizedSlug = normalizeSlugPath(slug);
   const fallback =
     seedPages.find((page) => normalizeSlugPath(page.slug) === normalizedSlug && page.status === "published") ?? null;
 
   // If Firebase isn't configured we still want the marketing site to render with seed content.
   if (!process.env.NEXT_PUBLIC_FIREBASE_API_KEY) {
-    return mergePageWithComponentsAndArticles(fallback, options?.tagFilter);
+    const page = await mergePageWithComponentsAndArticles(fallback, options?.tagFilter);
+    return { page, source: page ? "seed" : "not_found" };
   }
 
   try {
@@ -283,13 +291,26 @@ export async function getPublishedPageBySlug(
       snapshot = await getDocs(altQuery);
     }
 
-    if (snapshot.empty) return mergePageWithComponentsAndArticles(fallback, options?.tagFilter);
-    const page = fromSnapshot(snapshot.docs[0]);
-    return mergePageWithComponentsAndArticles(page, options?.tagFilter);
+    if (snapshot.empty) {
+      const page = await mergePageWithComponentsAndArticles(fallback, options?.tagFilter);
+      return { page, source: page ? "seed" : "not_found" };
+    }
+    const firestorePage = fromSnapshot(snapshot.docs[0]);
+    const page = await mergePageWithComponentsAndArticles(firestorePage, options?.tagFilter);
+    return { page, source: "firestore" };
   } catch (error) {
     console.error("Failed to load published page from Firestore", error);
-    return mergePageWithComponentsAndArticles(fallback, options?.tagFilter);
+    const page = await mergePageWithComponentsAndArticles(fallback, options?.tagFilter);
+    return { page, source: page ? "seed" : "not_found" };
   }
+}
+
+export async function getPublishedPageBySlug(
+  slug: string,
+  options?: { tagFilter?: string | null }
+): Promise<PageRecord | null> {
+  const { page } = await getPublishedPageBySlugWithSource(slug, options);
+  return page;
 }
 
 export async function getPublishedPages(): Promise<PageRecord[]> {


### PR DESCRIPTION
## Summary
- **DevDataSourceBanner now gets data from the actual render pipeline** — receives source/block info as props from the server component instead of calling `/api/admin/inspect` (which uses firebase-admin, a different SDK than the page render)
- **Fixes the core Claude confusion**: banner was showing "Source: SEED" with 6 placeholder blocks even when the page was rendering 1 real block from Firestore
- **Added `getPublishedPageBySlugWithSource()`** to `pageContent.ts` — returns both page data and its source ("firestore" | "seed" | "not_found")
- **Removed duplicate banner** from `layout.tsx` (was rendering a second prop-less banner)

## Context
Claude kept getting confused about page content because the banner reported seed data blocks while the actual page rendered Firestore data. The inspect API uses `firebase-admin` which requires `FIREBASE_SERVICE_ACCOUNT_JSON`, while page rendering uses the client Firebase SDK with `NEXT_PUBLIC_FIREBASE_*` vars — they can give different answers.

## Test plan
- [ ] Dev server shows green "Source: FIRESTORE" banner on home page
- [ ] Banner block count matches actual rendered blocks
- [ ] No duplicate banners
- [ ] Production build unaffected (banner only renders in dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)